### PR TITLE
refactor(webpack-config): rename gwwebpack to gewebpack

### DIFF
--- a/packages/webpack-config/webpackPkgConfig.js
+++ b/packages/webpack-config/webpackPkgConfig.js
@@ -1,5 +1,3 @@
-const { pkg } = require('@goldwasserexchange/read-pkg-up-helpers');
+const { pkg: { gewebpack = {} } = require('@goldwasserexchange/read-pkg-up-helpers');
 
-const webpackPkgConfig = pkg.gewebpack || {};
-
-module.exports = webpackPkgConfig;
+module.exports = gewebpack;

--- a/packages/webpack-config/webpackPkgConfig.js
+++ b/packages/webpack-config/webpackPkgConfig.js
@@ -1,5 +1,5 @@
 const { pkg } = require('@goldwasserexchange/read-pkg-up-helpers');
 
-const webpackPkgConfig = pkg.gwwebpack || {};
+const webpackPkgConfig = pkg.gewebpack || {};
 
 module.exports = webpackPkgConfig;

--- a/packages/webpack-config/webpackPkgConfig.js
+++ b/packages/webpack-config/webpackPkgConfig.js
@@ -1,3 +1,3 @@
-const { pkg: { gewebpack = {} } = require('@goldwasserexchange/read-pkg-up-helpers');
+const { pkg: { gewebpack = {} } } = require('@goldwasserexchange/read-pkg-up-helpers');
 
 module.exports = gewebpack;


### PR DESCRIPTION
affects: @goldwasserexchange/webpack-config

the key gwwebpack of package.json wasn't following our naming conventions, goldwasser exchange is
abreviatted ge and not gw

BREAKING CHANGE:
you need to change the gwwebpack key of package.json to gewebpack

ISSUES CLOSED: #28