### PR TITLE
feat(webpack-config): support js config files for gewebpack

### DIFF
--- a/packages/webpack-config/utils/requireFromRootIfString.js
+++ b/packages/webpack-config/utils/requireFromRootIfString.js
@@ -1,0 +1,9 @@
+const { is, when } = require('ramda');
+const { fromRoot } = require('@goldwasserexchange/read-pkg-up-helpers');
+
+const requireFromRootIfString = when(
+  is(String),
+  str => require(fromRoot(str)), // eslint-disable-line import/no-dynamic-require,global-require
+);
+
+module.exports = requireFromRootIfString;

--- a/packages/webpack-config/webpackPkgConfig.js
+++ b/packages/webpack-config/webpackPkgConfig.js
@@ -1,3 +1,4 @@
 const { pkg: { gewebpack = {} } } = require('@goldwasserexchange/read-pkg-up-helpers');
+const requireFromRootIfString = require('./utils/requireFromRootIfString');
 
-module.exports = gewebpack;
+module.exports = requireFromRootIfString(gewebpack);


### PR DESCRIPTION
affects: @goldwasserexchange/webpack-config

if  the gewebpack package.json key is a string use it as a path to require a js/json file to load
the config

ISSUES CLOSED: #32